### PR TITLE
Improve GPIO API

### DIFF
--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -7,7 +7,6 @@ extern crate panic_itm;
 
 use cortex_m_rt::entry;
 use hal::{
-    gpio::{Input, Output, Pin, PushPull},
     pac::Peripherals,
     prelude::*,
 };
@@ -18,27 +17,27 @@ fn main() -> ! {
     let mut cmu = peripherals.CMU;
     let gpio = peripherals.GPIO.split(&mut cmu);
 
-    let mut led0: Pin<_, Output<PushPull>> = gpio.pf4.into();
-    let mut led1: Pin<_, Output<PushPull>> = gpio.pf5.into();
+    let mut led0 = gpio.pf4.push_pull_output();
+    let mut led1 = gpio.pf5.push_pull_output();
 
     // External pull-up resistor is too weak. Touching the backside of the
     // board makes the input toggle. Enable the internal pull-up improve
     // input noise resistance.
-    let btn0: Pin<_, Input> = gpio.pf6.pull_up().into();
-    let btn1: Pin<_, Input> = gpio.pf7.pull_up().into();
+    let btn0 = gpio.pf6.pull_up().input();
+    let btn1 = gpio.pf7.pull_up().input();
 
     // Each button controls a LED.
     loop {
         if btn0.is_low().unwrap() {
-            led0.set_high().unwrap();
+            led0.set_high().ok();
         } else {
-            led0.set_low().unwrap();
+            led0.set_low().ok();
         }
 
         if btn1.is_low().unwrap() {
-            led1.set_high().unwrap();
+            led1.set_high().ok();
         } else {
-            led1.set_low().unwrap();
+            led1.set_low().ok();
         }
     }
 }

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -6,10 +6,7 @@ use efm32pg12_hal as hal;
 extern crate panic_itm;
 
 use cortex_m_rt::entry;
-use hal::{
-    pac::Peripherals,
-    prelude::*,
-};
+use hal::{pac::Peripherals, prelude::*};
 
 #[entry]
 fn main() -> ! {
@@ -17,8 +14,8 @@ fn main() -> ! {
     let mut cmu = peripherals.CMU;
     let gpio = peripherals.GPIO.split(&mut cmu);
 
-    let mut led0 = gpio.pf4.push_pull_output();
-    let mut led1 = gpio.pf5.push_pull_output();
+    let mut led0 = gpio.pf4.push_pull_output(false);
+    let mut led1 = gpio.pf5.push_pull_output(false);
 
     // External pull-up resistor is too weak. Touching the backside of the
     // board makes the input toggle. Enable the internal pull-up improve

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -10,7 +10,7 @@ use crate::{
         GPIO,
     },
 };
-use core::marker::PhantomData;
+use core::{convert::Infallible, marker::PhantomData};
 
 /// Extension trait to use the peripheral bit set and clear feature.
 trait GpioClearSetExt {
@@ -564,7 +564,7 @@ where
     T: PinTrait,
     M: Mode + InputAvailable,
 {
-    type Error = ();
+    type Error = Infallible;
 
     fn is_low(&self) -> Result<bool, Self::Error> {
         Ok(!self.ty.read_din_bit())
@@ -576,7 +576,7 @@ where
 }
 
 impl<T: PinTrait> OutputPin for Pin<T, Output> {
-    type Error = ();
+    type Error = Infallible;
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
         self.ty.clear_dout_bit();
@@ -600,7 +600,7 @@ impl<T: PinTrait> StatefulOutputPin for Pin<T, Output> {
 }
 
 impl<T: PinTrait> ToggleableOutputPin for Pin<T, Output> {
-    type Error = ();
+    type Error = Infallible;
 
     fn toggle(&mut self) -> Result<(), Self::Error> {
         self.ty.write_douttgl_bit();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -243,6 +243,9 @@ mod builder_types {
 }
 
 /// Builder type for pins.
+/// 
+/// Finalization methods like `input()` or `PinBuilder::push_pull_output()` are
+/// only implemented for configurations that are supported by the hardware.
 ///
 /// This can be obtained by accessing a field of [`Parts`] or by calling
 /// [`Pin::reset()`] on an existing pin.
@@ -348,13 +351,17 @@ pub struct Output;
 impl Mode for Output {}
 
 /// GPIO pin
-// TODO: More documentation
+///
+/// Use a [`PinBuilder`] to create a pin. To change a pin configuration
+/// use the [`Pin::reset()`] method to get back a builder. The cycle through
+/// disabled mode prevents a pin from entering unwanted intermediate modes.
 pub struct Pin<T: PinTrait, M: Mode> {
     ty: T,
     _mode: PhantomData<M>,
 }
 
 impl<T: PinTrait, M: Mode> Pin<T, M> {
+    /// Disables the pin and returns a builder.
     pub fn reset(mut self) -> PinBuilder<T, Floating, NoFilter> {
         self.ty.clear_mode();
 
@@ -374,6 +381,7 @@ impl<T: PinTrait, M: Mode> Pin<T, M> {
 }
 
 impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    /// Disables the digital input and output circuitry for this pin.
     pub fn disabled(self) -> Pin<T, Disabled> {
         Pin {
             ty: self.ty,
@@ -383,6 +391,7 @@ impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
+    /// Disables the digital input and output circuitry for this pin.
     pub fn disabled(mut self) -> Pin<T, Disabled> {
         self.ty.set_dout_bit();
 
@@ -394,6 +403,7 @@ impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    /// Configures this pin as digital input.
     pub fn input(mut self) -> Pin<T, Input> {
         self.ty.set_mode(MODE::INPUT);
 
@@ -405,6 +415,7 @@ impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, Floating, Filter> {
+    /// Configures this pin as digital input.
     pub fn input(mut self) -> Pin<T, Input> {
         // Change to INPUT mode first, so that setting the DOUT bit does not
         // accidentally activate the pull-up resistor while still in DISABLED mode.
@@ -419,6 +430,7 @@ impl<T: PinTrait> PinBuilder<T, Floating, Filter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullDown, NoFilter> {
+    /// Configures this pin as digital input.
     pub fn input(mut self) -> Pin<T, Input> {
         self.ty.set_mode(MODE::INPUTPULL);
 
@@ -430,6 +442,7 @@ impl<T: PinTrait> PinBuilder<T, PullDown, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
+    /// Configures this pin as digital input.
     pub fn input(mut self) -> Pin<T, Input> {
         self.ty.set_dout_bit();
         self.ty.set_mode(MODE::INPUTPULL);
@@ -442,6 +455,7 @@ impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullDown, Filter> {
+    /// Configures this pin as digital input.
     pub fn input(mut self) -> Pin<T, Input> {
         self.ty.set_mode(MODE::INPUTPULLFILTER);
 
@@ -453,6 +467,7 @@ impl<T: PinTrait> PinBuilder<T, PullDown, Filter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullUp, Filter> {
+    /// Configures this pin as digital input.
     pub fn input(mut self) -> Pin<T, Input> {
         self.ty.set_dout_bit();
         self.ty.set_mode(MODE::INPUTPULLFILTER);
@@ -465,6 +480,7 @@ impl<T: PinTrait> PinBuilder<T, PullUp, Filter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    /// Configures this pin as push-pull output.
     pub fn push_pull_output(mut self) -> Pin<T, Output> {
         if self.state {
             self.ty.set_dout_bit();
@@ -479,6 +495,7 @@ impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    /// Configures this pin as open-source output.
     pub fn open_source_output(mut self) -> Pin<T, Output> {
         self.ty.set_mode(MODE::WIREDOR);
         if self.state {
@@ -493,6 +510,7 @@ impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullDown, NoFilter> {
+    /// Configures this pin as open-source output.
     pub fn open_source_output(mut self) -> Pin<T, Output> {
         self.ty.set_mode(MODE::WIREDORPULLDOWN);
         if self.state {
@@ -507,6 +525,7 @@ impl<T: PinTrait> PinBuilder<T, PullDown, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    /// Configures this pin as open-drain output.
     pub fn open_drain_output(mut self) -> Pin<T, Output> {
         if self.state {
             self.ty.set_dout_bit();
@@ -521,6 +540,7 @@ impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, Floating, Filter> {
+    /// Configures this pin as open-drain output.
     pub fn open_drain_output(mut self) -> Pin<T, Output> {
         if self.state {
             self.ty.set_dout_bit();
@@ -535,6 +555,7 @@ impl<T: PinTrait> PinBuilder<T, Floating, Filter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
+    /// Configures this pin as open-drain output.
     pub fn open_drain_output(mut self) -> Pin<T, Output> {
         if self.state {
             self.ty.set_dout_bit();
@@ -549,6 +570,7 @@ impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
 }
 
 impl<T: PinTrait> PinBuilder<T, PullUp, Filter> {
+    /// Configures this pin as open-drain output.
     pub fn open_drain_output(mut self) -> Pin<T, Output> {
         if self.state {
             self.ty.set_dout_bit();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -344,25 +344,8 @@ pub struct Input;
 impl Mode for Input {}
 
 /// Marks a GPIO pin as being configured as output.
-pub struct Output<OM: OutputMode>(OM);
-impl<OM: OutputMode> Mode for Output<OM> {}
-
-/// Implemented by types that indicate a GPIO output mode.
-///
-/// Used as trait bound by the [`Output`] type.
-pub trait OutputMode {}
-
-/// Marks a GPIO output pin as push-pull.
-pub struct PushPull;
-impl OutputMode for PushPull {}
-
-/// Marks a GPIO output pin as open-source.
-pub struct OpenSource;
-impl OutputMode for OpenSource {}
-
-/// Marks a GPIO output pin as open-drain.
-pub struct OpenDrain;
-impl OutputMode for OpenDrain {}
+pub struct Output;
+impl Mode for Output {}
 
 /// GPIO pin
 // TODO: More documentation
@@ -371,10 +354,7 @@ pub struct Pin<T: PinTrait, M: Mode> {
     _mode: PhantomData<M>,
 }
 
-impl<T, M: Mode> Pin<T, M>
-where
-    T: PinTrait,
-{
+impl<T: PinTrait, M: Mode> Pin<T, M> {
     pub fn reset(mut self) -> PinBuilder<T, Floating, NoFilter> {
         self.ty.clear_mode();
 
@@ -393,235 +373,190 @@ where
     }
 }
 
-impl<T> From<PinBuilder<T, Floating, NoFilter>> for Pin<T, Disabled>
-where
-    T: PinTrait,
-{
-    fn from(pb: PinBuilder<T, Floating, NoFilter>) -> Self {
-        Self {
-            ty: pb.ty,
+impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    pub fn disabled(self) -> Pin<T, Disabled> {
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullUp, NoFilter>> for Pin<T, Disabled>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullUp, NoFilter>) -> Self {
-        pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
+    pub fn disabled(mut self) -> Pin<T, Disabled> {
+        self.ty.set_dout_bit();
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, Floating, NoFilter>> for Pin<T, Input>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, Floating, NoFilter>) -> Self {
-        pb.ty.set_mode(MODE::INPUT);
+impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    pub fn input(mut self) -> Pin<T, Input> {
+        self.ty.set_mode(MODE::INPUT);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, Floating, Filter>> for Pin<T, Input>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, Floating, Filter>) -> Self {
+impl<T: PinTrait> PinBuilder<T, Floating, Filter> {
+    pub fn input(mut self) -> Pin<T, Input> {
         // Change to INPUT mode first, so that setting the DOUT bit does not
         // accidentally activate the pull-up resistor while still in DISABLED mode.
-        pb.ty.set_mode(MODE::INPUT);
-        pb.ty.set_dout_bit();
+        self.ty.set_mode(MODE::INPUT);
+        self.ty.set_dout_bit();
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullDown, NoFilter>> for Pin<T, Input>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullDown, NoFilter>) -> Self {
-        pb.ty.set_mode(MODE::INPUTPULL);
+impl<T: PinTrait> PinBuilder<T, PullDown, NoFilter> {
+    pub fn input(mut self) -> Pin<T, Input> {
+        self.ty.set_mode(MODE::INPUTPULL);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullUp, NoFilter>> for Pin<T, Input>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullUp, NoFilter>) -> Self {
-        pb.ty.set_dout_bit();
-        pb.ty.set_mode(MODE::INPUTPULL);
+impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
+    pub fn input(mut self) -> Pin<T, Input> {
+        self.ty.set_dout_bit();
+        self.ty.set_mode(MODE::INPUTPULL);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullDown, Filter>> for Pin<T, Input>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullDown, Filter>) -> Self {
-        pb.ty.set_mode(MODE::INPUTPULLFILTER);
+impl<T: PinTrait> PinBuilder<T, PullDown, Filter> {
+    pub fn input(mut self) -> Pin<T, Input> {
+        self.ty.set_mode(MODE::INPUTPULLFILTER);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullUp, Filter>> for Pin<T, Input>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullUp, Filter>) -> Self {
-        pb.ty.set_dout_bit();
-        pb.ty.set_mode(MODE::INPUTPULLFILTER);
+impl<T: PinTrait> PinBuilder<T, PullUp, Filter> {
+    pub fn input(mut self) -> Pin<T, Input> {
+        self.ty.set_dout_bit();
+        self.ty.set_mode(MODE::INPUTPULLFILTER);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, Floating, NoFilter>> for Pin<T, Output<PushPull>>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, Floating, NoFilter>) -> Self {
-        if pb.state {
-            pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    pub fn push_pull_output(mut self) -> Pin<T, Output> {
+        if self.state {
+            self.ty.set_dout_bit();
         }
-        pb.ty.set_mode(MODE::PUSHPULL);
+        self.ty.set_mode(MODE::PUSHPULL);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, Floating, NoFilter>> for Pin<T, Output<OpenSource>>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, Floating, NoFilter>) -> Self {
-        pb.ty.set_mode(MODE::WIREDOR);
-        if pb.state {
-            pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    pub fn open_source_output(mut self) -> Pin<T, Output> {
+        self.ty.set_mode(MODE::WIREDOR);
+        if self.state {
+            self.ty.set_dout_bit();
         }
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullDown, NoFilter>> for Pin<T, Output<OpenSource>>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullDown, NoFilter>) -> Self {
-        pb.ty.set_mode(MODE::WIREDORPULLDOWN);
-        if pb.state {
-            pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, PullDown, NoFilter> {
+    pub fn open_source_output(mut self) -> Pin<T, Output> {
+        self.ty.set_mode(MODE::WIREDORPULLDOWN);
+        if self.state {
+            self.ty.set_dout_bit();
         }
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, Floating, NoFilter>> for Pin<T, Output<OpenDrain>>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, Floating, NoFilter>) -> Self {
-        if pb.state {
-            pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, Floating, NoFilter> {
+    pub fn open_drain_output(mut self) -> Pin<T, Output> {
+        if self.state {
+            self.ty.set_dout_bit();
         }
-        pb.ty.set_mode(MODE::WIREDAND);
+        self.ty.set_mode(MODE::WIREDAND);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, Floating, Filter>> for Pin<T, Output<OpenDrain>>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, Floating, Filter>) -> Self {
-        if pb.state {
-            pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, Floating, Filter> {
+    pub fn open_drain_output(mut self) -> Pin<T, Output> {
+        if self.state {
+            self.ty.set_dout_bit();
         }
-        pb.ty.set_mode(MODE::WIREDANDFILTER);
+        self.ty.set_mode(MODE::WIREDANDFILTER);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullUp, NoFilter>> for Pin<T, Output<OpenDrain>>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullUp, NoFilter>) -> Self {
-        if pb.state {
-            pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, PullUp, NoFilter> {
+    pub fn open_drain_output(mut self) -> Pin<T, Output> {
+        if self.state {
+            self.ty.set_dout_bit();
         }
-        pb.ty.set_mode(MODE::WIREDANDPULLUP);
+        self.ty.set_mode(MODE::WIREDANDPULLUP);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
 }
 
-impl<T> From<PinBuilder<T, PullUp, Filter>> for Pin<T, Output<OpenDrain>>
-where
-    T: PinTrait,
-{
-    fn from(mut pb: PinBuilder<T, PullUp, Filter>) -> Self {
-        if pb.state {
-            pb.ty.set_dout_bit();
+impl<T: PinTrait> PinBuilder<T, PullUp, Filter> {
+    pub fn open_drain_output(mut self) -> Pin<T, Output> {
+        if self.state {
+            self.ty.set_dout_bit();
         }
-        pb.ty.set_mode(MODE::WIREDANDPULLUPFILTER);
+        self.ty.set_mode(MODE::WIREDANDPULLUPFILTER);
 
-        Self {
-            ty: pb.ty,
+        Pin {
+            ty: self.ty,
             _mode: PhantomData,
         }
     }
@@ -631,7 +566,7 @@ where
 /// Leaked because it is used as trait bound. Not relevant for the user.
 pub trait InputAvailable {}
 impl InputAvailable for Input {}
-impl<OM: OutputMode> InputAvailable for Output<OM> {}
+impl InputAvailable for Output {}
 
 impl<T, M> InputPin for Pin<T, M>
 where
@@ -649,11 +584,7 @@ where
     }
 }
 
-impl<T, OM> OutputPin for Pin<T, Output<OM>>
-where
-    T: PinTrait,
-    OM: OutputMode,
-{
+impl<T: PinTrait> OutputPin for Pin<T, Output> {
     type Error = ();
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
@@ -667,11 +598,7 @@ where
     }
 }
 
-impl<T, OM> StatefulOutputPin for Pin<T, Output<OM>>
-where
-    T: PinTrait,
-    OM: OutputMode,
-{
+impl<T: PinTrait> StatefulOutputPin for Pin<T, Output> {
     fn is_set_low(&self) -> Result<bool, Self::Error> {
         Ok(!self.ty.read_dout_bit())
     }
@@ -681,11 +608,7 @@ where
     }
 }
 
-impl<T, OM> ToggleableOutputPin for Pin<T, Output<OM>>
-where
-    T: PinTrait,
-    OM: OutputMode,
-{
+impl<T: PinTrait> ToggleableOutputPin for Pin<T, Output> {
     type Error = ();
 
     fn toggle(&mut self) -> Result<(), Self::Error> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -339,10 +339,6 @@ pub trait Mode {}
 pub struct Disabled;
 impl Mode for Disabled {}
 
-/// Marks a GPIO pin as being used by a debug connection (SDW or JTAG).
-pub struct Debug;
-impl Mode for Debug {}
-
 /// Marks a GPIO pin as being configured as input.
 pub struct Input;
 impl Mode for Input {}


### PR DESCRIPTION
Use dedicated finalization methods for the GPIO pin builder.
The user does not have to import and specify the pin types anymore.